### PR TITLE
Allow passing VMs & disks folders as parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This module contains basic configuration tasks for Microsoft Hyper-V. It is stil
  2. Install additional features: Hyper-V module for PowerShell and GUI management tools.
  3. Configure live migration parameters.
  4. Create and configure virtual switches.
+ 5. Configure the folders for the configuration files and virtual disks.
 
 Basic usage
 -----------
@@ -14,6 +15,15 @@ The basic scenario allows the user to configure the **Hyper-V role** and the add
     class { 'hyper_v':
       ensure_powershell => present,
       ensure_tools      => present,
+    }
+
+If you want to customize where **Hyper-V** should put the configuration files or the virtual disks, you can use the following parameters:
+
+    class { 'hyper_v':
+      ensure_powershell         => present,
+      ensure_tools              => present,
+      virtual_hard_disks_folder => 'D:\',
+      virtual_machines_folder   => 'D:\Hyper-V',
     }
 
 To configure **live migration** parameters, an specific class is provided:


### PR DESCRIPTION
This patch allows the user to pass the folders for the virtual machines configuration files and virtual disks.

Example:

```
class { 'hyper_v':
  ensure_powershell         => present,
  ensure_tools              => present,
  virtual_hard_disks_folder => 'D:\',
  virtual_machines_folder   => 'D:\Hyper-V',
}
```

The patch is added because because OpenStack is able to handle with `instance_path` where to put the virtual disk, but we also want to configure where the configuration files are stored.

Take a look and let me know if it's good for you.
