### PR TITLE
Improve regexp for vswitch attributes

### DIFF
--- a/lib/puppet/provider/virtual_switch/virtual_switch.rb
+++ b/lib/puppet/provider/virtual_switch/virtual_switch.rb
@@ -36,8 +36,8 @@ Puppet::Type.type(:virtual_switch).provide(:virtual_switch) do
   end
 
   def type
-    type = powershell(%/(Get-VMSwitch "#{resource[:name]}").SwitchType/)
-    type =~/^(.*)/
+    type = powershell(%/(Get-VMSwitch "#{resource[:name]}") | FL SwitchType/)
+    type =~/^SwitchType : (.*)/
     $1
   end
   def type=(value)
@@ -49,8 +49,8 @@ Puppet::Type.type(:virtual_switch).provide(:virtual_switch) do
   end
 
   def notes
-    notes = powershell(%/(Get-VMSwitch "#{resource[:name]}").Notes/)
-    notes =~ /^(.*)/
+    notes = powershell(%/Get-VMSwitch "#{resource[:name]}" |FL Notes/)
+    notes =~ /^Notes : (.*)/
     $1
   end
   def notes=(value)
@@ -77,8 +77,8 @@ Puppet::Type.type(:virtual_switch).provide(:virtual_switch) do
   end
 
   def os_managed
-    os_managed = powershell(%/(Get-VMSwitch "#{resource[:name]}").AllowManagementOS/)
-    os_managed =~ /^(.*)/
+    os_managed = powershell(%/(Get-VMSwitch "#{resource[:name]}") | FL AllowManagementOS/)
+    os_managed =~ /^AllowManagementOS : (.*)/
     case $1
     when 'True'
       true


### PR DESCRIPTION
I've updated the definition of the custom type `virtual_switch` to change how the vswitch attributes are extracted from the output.

Without this patch, if you have a warning in powershell (that could be produced by other elements in the system), the type won't get the right information. This patch will restrict the output to the value starting right after the caption of the attribute.
